### PR TITLE
Acme/Formatting: add simple API to ship

### DIFF
--- a/acme/formatting.h
+++ b/acme/formatting.h
@@ -1,0 +1,60 @@
+
+#ifndef _ACME_FORMATTING
+
+#include <format>
+#include <iostream>
+#include <string>
+#include <utility>
+
+#include "framework.h"
+
+#define _FMT_DEF inline
+
+// Simple specialization for strings in the Ca2 framework.
+// This just uses ::string::c_str() to format.
+template<>
+struct std::formatter<::string> : std::formatter<std::string> {
+    template<class FormatContext>
+    auto format(const ::string& value, FormatContext& fc) const
+    {
+        return std::formatter<std::string>::format(value.c_str(), fc);
+    }
+};
+
+// NOTE: "fmt" is marked as const in all of these function declarations 
+// because std::format() also does this. I'm just following what they've 
+// done as I assume there's good reason.
+
+template<typename... Ts>
+_FMT_DEF ::string format(const std::format_string<Ts...> fmt, Ts&&... args) {
+    return ::string(std::format(fmt, std::forward<Ts>(args)...));
+}
+
+// print formatted output to std::cout without a newline
+_FMT_DEF ::string print(const std::format_string<Ts...> fmt, Ts&&... args) {
+    const auto _Fmtd = std::format(fmt, std::forward<Ts>(args)...);
+    std::cout << _Fmtd;
+}
+
+// print formatted output to std::cout with a newline
+_FMT_DEF::string println(const std::format_string<Ts...> fmt, Ts&&... args) {
+    const auto _Fmtd = std::format(fmt, std::forward<Ts>(args)...);
+    std::cout << _Fmtd << '\n';
+}
+
+// print formatted output to std::cerr without a newline
+_FMT_DEF ::string eprint(const std::format_string<Ts...> fmt, Ts&&... args) {
+    const auto _Fmtd = std::format(fmt, std::forward<Ts>(args)...);
+    std::cerr << _Fmtd;
+}
+
+// print formatted output to std::cerr with a newline
+_FMT_DEF ::string eprintln(const std::format_string<Ts...> fmt, Ts&&... args) {
+    const auto _Fmtd = std::format(fmt, std::forward<Ts>(args)...);
+    std::cerr << _Fmtd << '\n';
+}
+
+#undef _FMT_DEF
+
+#define _ACME_FORMATTING
+#endif


### PR DESCRIPTION
This pull request is related to #16 

This adds a basic API to use formatting.

This includes formatting, outputting formatted data to std::cout & std::cerr.

I have no way of testing this, so someone will need to attempt to build it. If there are any problems report them to me and I'll sort them.